### PR TITLE
chore: enable auto-merge for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+  "platformAutomerge": true,
+  "automerge": true,
+  "automergeType": "pr",
   "packageRules": [
     {
       "groupName": "NestJS packages",
@@ -36,12 +39,15 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "automerge": false
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
     },
     {
       "matchUpdateTypes": ["major"],
       "labels": ["breaking-change"],
-      "automerge": false
+      "automerge": false,
+      "dependencyDashboardApproval": true
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
## 🤖 Auto-Merge Automático para Renovate

Esta PR configura o Renovate para fazer **merge automático** de atualizações seguras.

### ✅ Mudanças:

**Habilitado auto-merge para:**
- ✅ Updates **minor** (ex: 1.0.0 → 1.1.0)
- ✅ Updates **patch** (ex: 1.0.0 → 1.0.1)

**Ainda requer aprovação manual para:**
- ⚠️ Updates **major** (ex: 1.0.0 → 2.0.0) - breaking changes

### 🔧 Configurações adicionadas:

```json
"platformAutomerge": true,
"automerge": true,
"automergeType": "pr",
```

### 📋 Como funciona:

1. **Renovate cria a PR** (como de costume)
2. **CI/testes executam** automaticamente
3. **Se tudo passar** ✅ → Renovate faz merge sozinho
4. **Se falhar** ❌ → PR fica aberta para revisão manual

### 🎯 Benefícios:

- ✅ Dependências sempre atualizadas
- ✅ Sem necessidade de aprovação manual para updates seguros
- ✅ Breaking changes ainda precisam de revisão
- ✅ Segurança mantida (CI precisa passar)

---

**Após fazer merge desta PR, todas as futuras PRs de minor/patch do Renovate serão mergeadas automaticamente quando os testes passarem!**