### PR TITLE
fix(test): Add @/ path alias to Jest E2E config

### DIFF
--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -7,6 +7,7 @@
     "^.+\\.(t|j)s$": "ts-jest"
   },
   "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/src/$1",
     "^@mag-system/core$": "<rootDir>/../../packages/core/src",
     "^@mag-system/database$": "<rootDir>/../../packages/database/src"
   },


### PR DESCRIPTION
## 🐛 Problema

Testes E2E falhavam com:
```
Cannot find module '@/database/prisma.service' from 'src/modules/auth/auth.service.ts'
```

**Causa:** O alias `@/` está configurado no `tsconfig.json` mas não no Jest.

---

## ✅ Solução

### **Arquivo:** `apps/api/test/jest-e2e.json`

**Adição:**
```json
{
  "moduleNameMapper": {
    "^@/(.*)$": "<rootDir>/src/$1",
    "^@mag-system/core$": "<rootDir>/../../packages/core/src",
    "^@mag-system/database$": "<rootDir>/../../packages/database/src"
  }
}
```

**O que faz:**
- `@/database/prisma.service` → `apps/api/src/database/prisma.service`
- `@/common/filters/...` → `apps/api/src/common/filters/...`
- Etc.

---

## 🔗 Contexto

O `tsconfig.json` já tinha:
```json
{
  "compilerOptions": {
    "baseUrl": "./src",
    "paths": {
      "@/*": ["./*"]
    }
  }
}
```

Mas Jest usa seu próprio sistema de resolução de módulos (`moduleNameMapper`).

---

## 🧪 Teste Após Merge

```powershell
# Merge
gh pr merge 20 --squash
git pull origin main

# Verificar senha do Docker
cat .env  # ou Get-Content .env

# Se POSTGRES_PASSWORD != postgres, ajustar:
docker-compose down
$env:POSTGRES_PASSWORD = "SUA_SENHA"  # ou editar .env
docker-compose up -d db
Start-Sleep -Seconds 10

# Rodar testes
$env:DATABASE_URL = "postgresql://postgres:SUA_SENHA@localhost:5432/mag_system"
cd packages/database
pnpm prisma migrate deploy
cd ../..
pnpm --filter @mag-system/api test:e2e
```

---

## ⚠️ Sobre a Senha do Banco

O erro:
```
P1000: Authentication failed against database server at `localhost`,
the provided database credentials for `postgres` are not valid.
```

**Soluções:**

1. **Verificar `.env` na raiz:**
```env
POSTGRES_PASSWORD=sua_senha_aqui
```

2. **Ou usar padrão do docker-compose:**
```powershell
# Se não tiver .env, cria:
@"
POSTGRES_USER=postgres
POSTGRES_PASSWORD=postgres
POSTGRES_DB=mag_system
"@ | Out-File -FilePath .env -Encoding utf8

# Recriar container
docker-compose down
docker-compose up -d db
```

---

## ✅ Checklist

- [x] `@/` alias adicionado ao Jest
- [x] Module mapper completo
- [ ] Testes passando (após resolver senha DB)

---

**Fixes:** `Cannot find module '@/database/prisma.service'`  
**Related:** #19 (Jest Module Mapper)