### PR TITLE
fix(core): Remove duplicate formatCPF/formatCNPJ exports

### DIFF
--- a/packages/core/src/validators/document.validator.ts
+++ b/packages/core/src/validators/document.validator.ts
@@ -110,26 +110,3 @@ export function isValidDocument(document: string): boolean {
 export function normalizeDocument(document: string): string {
   return document.replace(/\D/g, '');
 }
-
-/**
- * Formata CPF (###.###.###-##)
- * @param cpf - CPF sem máscara
- * @returns CPF formatado
- */
-export function formatCPF(cpf: string): string {
-  const cleanCPF = cpf.replace(/\D/g, '');
-  return cleanCPF.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
-}
-
-/**
- * Formata CNPJ (##.###.###/####-##)
- * @param cnpj - CNPJ sem máscara
- * @returns CNPJ formatado
- */
-export function formatCNPJ(cnpj: string): string {
-  const cleanCNPJ = cnpj.replace(/\D/g, '');
-  return cleanCNPJ.replace(
-    /(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/,
-    '$1.$2.$3/$4-$5',
-  );
-}


### PR DESCRIPTION
## 🐛 Problema

Compilação TypeScript falhava com:
```
error TS2308: Module './utils' has already exported a member named 'formatCNPJ'. 
Consider explicitly re-exporting to resolve the ambiguity.

error TS2308: Module './utils' has already exported a member named 'formatCPF'.
```

**Causa:** Funções `formatCPF` e `formatCNPJ` estavam duplicadas em:
1. `packages/core/src/utils/document.util.ts`
2. `packages/core/src/validators/document.validator.ts`

Ambos sendo exportados via `index.ts`, causando conflito.

---

## ✅ Solução

### **Removidas do `validators/document.validator.ts`:**

```diff
- export function formatCPF(cpf: string): string { ... }
- export function formatCNPJ(cnpj: string): string { ... }
```

**Mantidas apenas em `utils/document.util.ts`** (local correto para formatação).

### **Funções que PERMANECEM em `validators/document.validator.ts`:**
- ✅ `isValidCPF()`
- ✅ `isValidCNPJ()`
- ✅ `isValidDocument()`
- ✅ `normalizeDocument()`

---

## 📝 Estrutura Correta

### **validators/** (validações)
- `isValidCPF()`
- `isValidCNPJ()`
- `isValidDocument()`
- `normalizeDocument()`

### **utils/** (formatação e transformação)
- `formatCPF()`
- `formatCNPJ()`
- `cleanDocument()`
- `formatPlate()`

---

## 🧪 Teste Após Merge

```powershell
gh pr merge 21 --squash
git pull origin main

# Rebuild do pacote core
pnpm --filter @mag-system/core build

# Rodar testes
pnpm --filter @mag-system/api test:e2e
```

---

## ✅ Checklist

- [x] Duplicações removidas
- [x] Funções mantidas em locais corretos
- [x] Validators focados em validação
- [x] Utils focados em formatação
- [ ] Build passando
- [ ] Testes E2E passando

---

**Fixes:** `error TS2308: Module has already exported a member`  
**Related:** #12 (Error Handling Foundation - onde duplicações foram criadas)