### PR TITLE
fix(clients): Fix import path after validators refactor

### DIFF
--- a/apps/api/src/modules/clients/clients.service.ts
+++ b/apps/api/src/modules/clients/clients.service.ts
@@ -14,7 +14,7 @@ import {
   isValidCPF,
   isValidCNPJ,
   normalizeDocument,
-} from '@mag-system/core/validators/document.validator';
+} from '@mag-system/core';
 
 /**
  * Service de Clientes com validações de negócio


### PR DESCRIPTION
## 🐛 Problema

```
error TS2307: Cannot find module '@mag-system/core/validators/document.validator'
```

**Causa:** Após remover `formatCPF` e `formatCNPJ` do `validators/document.validator.ts`, o import específico quebrou.

---

## ✅ Solução

**Mudança simples na linha 13:**

```diff
- } from '@mag-system/core/validators/document.validator';
+ } from '@mag-system/core';
```

**Razão:** Todos os exports já estão disponíveis via `@mag-system/core` (via `index.ts`).

---

## 🧪 Teste

```powershell
gh pr merge 22 --squash
git pull origin main
pnpm --filter @mag-system/api test:e2e
```

---

**Fixes:** Import error após #21