### PR TITLE
fix(turbo): remove test outputs to fix cache warning

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,7 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
+      "outputs": []
     },
     "test:cov": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## 🎯 What

Fixes Turborepo warning about `test` task outputs not matching any files.

## 🐛 Problem

```
⚠️  WARNING no output files found for task @mag-system/core#test. 
    Please check your `outputs` key in `turbo.json`
```

Tests don't always generate coverage files, causing Turborepo cache inconsistency warnings.

## ✅ Solution

Changed `turbo.json` test task:

```diff
"test": {
  "dependsOn": ["^build"],
- "outputs": ["coverage/**"]
+ "outputs": []
}
```

**Rationale**:
- Unit tests are fast (< 30s total)
- Caching by output is incorrect for tests
- Tests should run every time (not cached)
- Coverage is a separate task (`test:cov`) that still caches properly

## 📦 Impact

- ✅ Removes warning from Turborepo output
- ✅ Tests still run correctly
- ✅ No performance impact (tests are fast)
- ✅ Better cache consistency

## 🧪 Testing

Run `pnpm test` - should complete without warnings:

```bash
✅ Tasks: 6 successful, 6 total
✅ No warnings about outputs
```

## 🔗 Related

Closes #26

## 🚦 Breaking Changes

None. This is a configuration fix.

---

**Ready for review and merge!** 🚀